### PR TITLE
Standardize any node handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    proformaxml (1.0.0)
+    proformaxml (1.1.0)
       activemodel (>= 5.2.3, < 8.0.0)
       activesupport (>= 5.2.3, < 8.0.0)
       dachsfisch (>= 0.2.0, < 1.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     proformaxml (1.0.0)
       activemodel (>= 5.2.3, < 8.0.0)
       activesupport (>= 5.2.3, < 8.0.0)
-      dachsfisch (>= 0.1.1, < 1.0.0)
+      dachsfisch (>= 0.2.0, < 1.0.0)
       nokogiri (>= 1.10.2, < 2.0.0)
       rubyzip (>= 1.2.2, < 3.0.0)
 
@@ -23,7 +23,7 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
-    dachsfisch (0.1.1)
+    dachsfisch (0.2.0)
       nokogiri (>= 1.14.1, < 2.0.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     proformaxml (1.0.0)
       activemodel (>= 5.2.3, < 8.0.0)
       activesupport (>= 5.2.3, < 8.0.0)
-      dachsfisch (>= 0.1.0, < 1.0.0)
+      dachsfisch (>= 0.1.1, < 1.0.0)
       nokogiri (>= 1.10.2, < 2.0.0)
       rubyzip (>= 1.2.2, < 3.0.0)
 

--- a/lib/proformaxml/helpers/export_helpers.rb
+++ b/lib/proformaxml/helpers/export_helpers.rb
@@ -31,20 +31,6 @@ module ProformaXML
         end
       end
 
-      def inner_meta_data(xml, namespace, data)
-        data.each do |key, value|
-          case value.class.name
-            when 'Hash'
-              # underscore is used to disambiguate tag names from ruby methods
-              xml[namespace].send("#{key}_") do |meta_data_xml|
-                inner_meta_data(meta_data_xml, namespace, value)
-              end
-            else
-              xml[namespace].send("#{key}_", value)
-          end
-        end
-      end
-
       def add_dachsfisch_node(xml, dachsfisch_node, node_name_fallback = nil)
         if dachsfisch_node.blank?
           xml.send(node_name_fallback, '') if node_name_fallback.present?

--- a/lib/proformaxml/helpers/export_helpers.rb
+++ b/lib/proformaxml/helpers/export_helpers.rb
@@ -42,12 +42,6 @@ module ProformaXML
         xml << xml_snippet
       end
 
-      def add_namespaces_to_header(header, custom_namespaces)
-        custom_namespaces.each do |namespace|
-          header["xmlns:#{namespace[:prefix]}"] = namespace[:uri]
-        end
-      end
-
       def add_parent_uuid_and_lang_to_header(header)
         header['lang'] = @task.language if @task.language.present?
         header['parent-uuid'] = @task.parent_uuid if @task.parent_uuid.present?

--- a/lib/proformaxml/helpers/import_helpers.rb
+++ b/lib/proformaxml/helpers/import_helpers.rb
@@ -78,21 +78,6 @@ module ProformaXML
         files_from_filerefs(test_configuration_node.search('filerefs'))
       end
 
-      # def meta_data(any_data_node, use_namespace: false)
-      #   # use_namespace forces the use of the namespace as hash key - it should only be used at the entry of the recursion
-      #   {}.tap do |any_data|
-      #     any_data_node.children.each do |node|
-      #       key = (use_namespace ? node.namespace.prefix : any_data_node.name).to_sym
-      #       any_data[key] = if node.node_type == Nokogiri::XML::Node::TEXT_NODE
-      #                         node.text
-      #                       else
-      #                         # preserve any existing data in the nested hash
-      #                         (any_data[key] || {}).merge meta_data(node)
-      #                       end
-      #     end
-      #   end
-      # end
-
       private
 
       def convert_xml_node_to_json(any_node)

--- a/lib/proformaxml/helpers/import_helpers.rb
+++ b/lib/proformaxml/helpers/import_helpers.rb
@@ -97,11 +97,16 @@ module ProformaXML
 
       def convert_xml_node_to_json(any_node)
         xml_snippet = Nokogiri::XML::DocumentFragment.new(Nokogiri::XML::Document.new, any_node)
-        namespaces = any_node.xpath('.|.//*').map(&:namespace).reject {|ns| ns.prefix.nil?}.map{|ns|{prefix: ns.prefix, href: ns.href}}.uniq
-        namespaces.each do |namespace|
+        all_namespaces(any_node).each do |namespace|
           xml_snippet.children.first.add_namespace_definition(namespace[:prefix], namespace[:href])
         end
         JSON.parse(Dachsfisch::XML2JSONConverter.perform(xml: xml_snippet.to_xml))
+      end
+
+      def all_namespaces(node)
+        node.xpath('.|.//*').map(&:namespace).reject do |ns|
+          ns.prefix.nil?
+        end.map {|ns| {prefix: ns.prefix, href: ns.href} }.uniq
       end
 
       def value_from_node(name, node, attribute)

--- a/lib/proformaxml/services/exporter.rb
+++ b/lib/proformaxml/services/exporter.rb
@@ -6,10 +6,9 @@ module ProformaXML
   class Exporter
     include ProformaXML::Helpers::ExportHelpers
 
-    def initialize(task:, custom_namespaces: [], version: nil)
+    def initialize(task:, version: nil)
       @files = {}
       @task = task
-      @custom_namespaces = custom_namespaces
       @version = version || SCHEMA_VERSIONS.first
       add_placeholders if @version == '2.0'
     end
@@ -113,7 +112,6 @@ module ProformaXML
         'xmlns' => "urn:proforma:v#{@version}",
         'uuid' => @task.uuid,
       }.tap do |header|
-        add_namespaces_to_header(header, @custom_namespaces)
         add_parent_uuid_and_lang_to_header(header)
       end
     end

--- a/lib/proformaxml/services/exporter.rb
+++ b/lib/proformaxml/services/exporter.rb
@@ -21,7 +21,7 @@ module ProformaXML
       doc = Nokogiri::XML(xmldoc)
       errors = validate(doc)
 
-      File.binwrite('../testfile.zip', write_to_zip(xmldoc).string)
+      # File.binwrite('../testfile.zip', write_to_zip(xmldoc).string)
       raise PostGenerateValidationError.new(errors) if errors.any?
 
       write_to_zip(xmldoc)

--- a/lib/proformaxml/services/exporter.rb
+++ b/lib/proformaxml/services/exporter.rb
@@ -22,9 +22,9 @@ module ProformaXML
       doc = Nokogiri::XML(xmldoc)
       errors = validate(doc)
 
+      File.binwrite('../testfile.zip', write_to_zip(xmldoc).string)
       raise PostGenerateValidationError.new(errors) if errors.any?
 
-      # File.binwrite('../testfile.zip', write_to_zip(xmldoc).string)
       write_to_zip(xmldoc)
     end
 
@@ -38,16 +38,12 @@ module ProformaXML
         xml.proglang({version: @task.proglang&.dig(:version)}, @task.proglang&.dig(:name))
 
         add_objects_to_xml(xml)
-        add_meta_data(xml)
+        add_dachsfisch_node(xml, @task.meta_data, 'meta-data')
       end
     end
 
     def add_internal_description_to_xml(xml, internal_description)
       xml.send(:'internal-description', internal_description) if internal_description.present?
-    end
-
-    def add_meta_data(xml)
-      xml.send(:'meta-data') { meta_data(xml, @task.meta_data) }
     end
 
     def add_objects_to_xml(xml)

--- a/lib/proformaxml/services/importer.rb
+++ b/lib/proformaxml/services/importer.rb
@@ -26,7 +26,7 @@ module ProformaXML
       @task_node = @doc.xpath('/xmlns:task')
 
       set_data
-      {task: @task, custom_namespaces: @custom_namespaces}
+      @task
     end
 
     private
@@ -38,17 +38,12 @@ module ProformaXML
     end
 
     def set_data
-      set_namespaces
       set_base_data
       set_files
       set_model_solutions
       set_tests
       set_meta_data
       set_extra_data
-    end
-
-    def set_namespaces
-      @custom_namespaces = @doc.namespaces.except('xmlns').map {|k, v| {prefix: k[6..], uri: v} }
     end
 
     def set_base_data

--- a/lib/proformaxml/services/importer.rb
+++ b/lib/proformaxml/services/importer.rb
@@ -83,8 +83,8 @@ module ProformaXML
     end
 
     def set_meta_data
-      meta_data_node = @task_node.xpath('xmlns:meta-data')
-      @task.meta_data = meta_data(meta_data_node, use_namespace: true) if meta_data_node.text.present?
+      meta_data_node = @task_node.xpath('xmlns:meta-data').first
+      @task.meta_data = convert_xml_node_to_json(meta_data_node) if meta_data_node.text.present?
     end
 
     def set_extra_data

--- a/lib/proformaxml/version.rb
+++ b/lib/proformaxml/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProformaXML
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/proformaxml.gemspec
+++ b/proformaxml.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activemodel', '>= 5.2.3', '< 8.0.0'
   spec.add_dependency 'activesupport', '>= 5.2.3', '< 8.0.0'
-  spec.add_dependency 'dachsfisch', '>= 0.1.0', '< 1.0.0'
+  spec.add_dependency 'dachsfisch', '>= 0.1.1', '< 1.0.0'
   spec.add_dependency 'nokogiri', '>= 1.10.2', '< 2.0.0'
   spec.add_dependency 'rubyzip', '>= 1.2.2', '< 3.0.0'
 

--- a/proformaxml.gemspec
+++ b/proformaxml.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activemodel', '>= 5.2.3', '< 8.0.0'
   spec.add_dependency 'activesupport', '>= 5.2.3', '< 8.0.0'
-  spec.add_dependency 'dachsfisch', '>= 0.1.1', '< 1.0.0'
+  spec.add_dependency 'dachsfisch', '>= 0.2.0', '< 1.0.0'
   spec.add_dependency 'nokogiri', '>= 1.10.2', '< 2.0.0'
   spec.add_dependency 'rubyzip', '>= 1.2.2', '< 3.0.0'
 

--- a/spec/custom_matchers/equal_task_spec.rb
+++ b/spec/custom_matchers/equal_task_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'equal_task matcher' do
     end
 
     context 'with a tiny change in the meta_data' do
-      before { task.meta_data[:namespace][:meta] = 'doto' }
+      before { task.meta_data['meta-data']['namespace:meta']['$1'] = 'doto' }
 
       it 'fails' do
         expect(task).not_to be_an_equal_task_as task2
@@ -73,7 +73,7 @@ RSpec.describe 'equal_task matcher' do
     end
 
     context 'with a tiny change in the nested meta_data' do
-      before { task.meta_data[:namespace][:nested][:test] = 'doto' }
+      before { task.meta_data['meta-data']['namespace:nested']['namespace:test']['namespace:abc']['$1'] = 'doto' }
 
       it 'fails' do
         expect(task).not_to be_an_equal_task_as task2

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -17,7 +17,6 @@ FactoryBot.define do
     trait(:with_embedded_bin_file) { files { build_list(:task_file, 1, :populated, :small_content, :binary) } }
     trait(:with_attached_txt_file) { files { build_list(:task_file, 1, :populated, :large_content, :text) } }
     trait(:with_attached_bin_file) { files { build_list(:task_file, 1, :populated, :large_content, :binary) } }
-    trait(:with_meta_data) { meta_data { {namespace: {meta: 'data', nested: {test: {abc: '123'}, foo: 'bar'}}} } }
 
     trait(:with_model_solution) { model_solutions { build_list(:model_solution, 1, :populated) } }
     trait(:with_test) { tests { build_list(:test, 1, :populated) } }
@@ -62,46 +61,45 @@ FactoryBot.define do
       external_resources do
         {
           'external-resources' => {
+            '@xmlns' => {'foo' => 'urn:custom:foobar'},
             'external-resource' => [
               {
+                '@xmlns' => {'foo' => 'urn:custom:foobar'},
                 '@id' => 'external-resource 1',
                 '@reference' => '1',
                 '@used-by-grader' => 'true',
                 '@visible' => 'delayed',
                 '@usage-by-lms' => 'download',
                 'internal-description' => {
+                  '@xmlns' => {'foo' => 'urn:custom:foobar'},
                   '$1' => 'internal-desc',
                 },
                 'foo:bar' => {
-                  '@xmlns' => {
-                    'foo' => 'urn:custom:foobar',
-                  },
+                  '@xmlns' => {'foo' => 'urn:custom:foobar'},
                   '@version' => '4',
                   'foo:content' => {
-                    '@xmlns' => {
-                      'foo' => 'urn:custom:foobar',
-                    }, '$1' => 'foobar'
+                    '@xmlns' => {'foo' => 'urn:custom:foobar'},
+                    '$1' => 'foobar',
                   },
                 },
               },
               {
+                '@xmlns' => {'foo' => 'urn:custom:foobar'},
                 '@id' => 'external-resource 2',
                 '@reference' => '2',
                 '@used-by-grader' => 'false',
                 '@visible' => 'no',
                 '@usage-by-lms' => 'edit',
                 'internal-description' => {
+                  '@xmlns' => {'foo' => 'urn:custom:foobar'},
                   '$1' => 'internal-desc',
                 },
                 'foo:bar' => {
-                  '@xmlns' => {
-                    'foo' => 'urn:custom:foobar',
-                  },
+                  '@xmlns' => {'foo' => 'urn:custom:foobar'},
                   '@version' => '5',
                   'foo:content' => {
-                    '@xmlns' => {
-                      'foo' => 'urn:custom:foobar',
-                    }, '$1' => 'barfoo'
+                    '@xmlns' => {'foo' => 'urn:custom:foobar'},
+                    '$1' => 'barfoo',
                   },
                 },
               },
@@ -127,6 +125,33 @@ FactoryBot.define do
                   '@weight' => '1',
                 },
               ],
+            },
+          },
+        }
+      end
+    end
+    trait(:with_meta_data) do
+      meta_data do
+        {
+          'meta-data' => {
+            '@xmlns' => {'namespace' => 'custom_namespace.org'},
+            'namespace:meta' => {
+              '$1' => 'data',
+               '@xmlns' => {'namespace' => 'custom_namespace.org'},
+            },
+            'namespace:nested' => {
+              '@xmlns' => {'namespace' => 'custom_namespace.org'},
+              'namespace:foo' => {
+                '$1' => 'bar',
+                 '@xmlns' => {'namespace' => 'custom_namespace.org'},
+              },
+              'namespace:test' => {
+                '@xmlns' => {'namespace' => 'custom_namespace.org'},
+                'namespace:abc' => {
+                  '$1' => '123',
+                   '@xmlns' => {'namespace' => 'custom_namespace.org'},
+                },
+              },
             },
           },
         }

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -64,41 +64,33 @@ FactoryBot.define do
             '@xmlns' => {'foo' => 'urn:custom:foobar'},
             'external-resource' => [
               {
-                '@xmlns' => {'foo' => 'urn:custom:foobar'},
                 '@id' => 'external-resource 1',
                 '@reference' => '1',
                 '@used-by-grader' => 'true',
                 '@visible' => 'delayed',
                 '@usage-by-lms' => 'download',
                 'internal-description' => {
-                  '@xmlns' => {'foo' => 'urn:custom:foobar'},
                   '$1' => 'internal-desc',
                 },
                 'foo:bar' => {
-                  '@xmlns' => {'foo' => 'urn:custom:foobar'},
                   '@version' => '4',
                   'foo:content' => {
-                    '@xmlns' => {'foo' => 'urn:custom:foobar'},
                     '$1' => 'foobar',
                   },
                 },
               },
               {
-                '@xmlns' => {'foo' => 'urn:custom:foobar'},
                 '@id' => 'external-resource 2',
                 '@reference' => '2',
                 '@used-by-grader' => 'false',
                 '@visible' => 'no',
                 '@usage-by-lms' => 'edit',
                 'internal-description' => {
-                  '@xmlns' => {'foo' => 'urn:custom:foobar'},
                   '$1' => 'internal-desc',
                 },
                 'foo:bar' => {
-                  '@xmlns' => {'foo' => 'urn:custom:foobar'},
                   '@version' => '5',
                   'foo:content' => {
-                    '@xmlns' => {'foo' => 'urn:custom:foobar'},
                     '$1' => 'barfoo',
                   },
                 },
@@ -137,19 +129,14 @@ FactoryBot.define do
             '@xmlns' => {'namespace' => 'custom_namespace.org'},
             'namespace:meta' => {
               '$1' => 'data',
-              '@xmlns' => {'namespace' => 'custom_namespace.org'},
             },
             'namespace:nested' => {
-              '@xmlns' => {'namespace' => 'custom_namespace.org'},
               'namespace:foo' => {
                 '$1' => 'bar',
-                '@xmlns' => {'namespace' => 'custom_namespace.org'},
               },
               'namespace:test' => {
-                '@xmlns' => {'namespace' => 'custom_namespace.org'},
                 'namespace:abc' => {
                   '$1' => '123',
-                  '@xmlns' => {'namespace' => 'custom_namespace.org'},
                 },
               },
             },

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -137,19 +137,19 @@ FactoryBot.define do
             '@xmlns' => {'namespace' => 'custom_namespace.org'},
             'namespace:meta' => {
               '$1' => 'data',
-               '@xmlns' => {'namespace' => 'custom_namespace.org'},
+              '@xmlns' => {'namespace' => 'custom_namespace.org'},
             },
             'namespace:nested' => {
               '@xmlns' => {'namespace' => 'custom_namespace.org'},
               'namespace:foo' => {
                 '$1' => 'bar',
-                 '@xmlns' => {'namespace' => 'custom_namespace.org'},
+                '@xmlns' => {'namespace' => 'custom_namespace.org'},
               },
               'namespace:test' => {
                 '@xmlns' => {'namespace' => 'custom_namespace.org'},
                 'namespace:abc' => {
                   '$1' => '123',
-                   '@xmlns' => {'namespace' => 'custom_namespace.org'},
+                  '@xmlns' => {'namespace' => 'custom_namespace.org'},
                 },
               },
             },

--- a/spec/factories/test.rb
+++ b/spec/factories/test.rb
@@ -28,29 +28,14 @@ FactoryBot.define do
             },
             'namespace:meta' => {
               '$1' => 'data',
-              '@xmlns' => {
-                'namespace' => 'custom_namespace.org',
-              },
             },
             'namespace:nested' => {
-              '@xmlns' => {
-                'namespace' => 'custom_namespace.org',
-              },
               'namespace:foo' => {
                 '$1' => 'bar',
-                '@xmlns' => {
-                  'namespace' => 'custom_namespace.org',
-                },
               },
               'namespace:test' => {
-                '@xmlns' => {
-                  'namespace' => 'custom_namespace.org',
-                },
                 'namespace:abc' => {
                   '$1' => '123',
-                  '@xmlns' => {
-                    'namespace' => 'custom_namespace.org',
-                  },
                 },
               },
             },
@@ -74,9 +59,7 @@ FactoryBot.define do
             '@framework' => 'JUnit',
             '@version' => '4.10',
             'unit:entry-point' => {
-              '@xmlns' => {
-                'unit' => 'urn:proforma:tests:unittest:v1.1',
-              }, '$1' => 'HelloWorldTest'
+              '$1' => 'HelloWorldTest',
             },
           },
         }
@@ -95,7 +78,8 @@ FactoryBot.define do
             'check:max-checkstyle-warnings' => {
               '@xmlns' => {
                 'unit' => 'urn:proforma:tests:java-checkstyle:v1.1',
-              }, '$1' => '4'
+              },
+              '$1' => '4',
             },
           },
         }
@@ -111,25 +95,13 @@ FactoryBot.define do
               'regex' => 'urn:proforma:tests:regexptest:v0.9',
             },
             'regex:entry-point' => {
-              '@xmlns' => {
-                'regex' => 'urn:proforma:tests:regexptest:v0.9',
-              },
               '$1' => 'HelloWorldTest',
             },
             'regex:parameter' => {
-              '@xmlns' => {
-                'regex' => 'urn:proforma:tests:regexptest:v0.9',
-              },
               '$1' => 'gui',
             },
             'regex:regular-expressions' => {
-              '@xmlns' => {
-                'regex' => 'urn:proforma:tests:regexptest:v0.9',
-              },
               'regex:regexp-disallow' => {
-                '@xmlns' => {
-                  'regex' => 'urn:proforma:tests:regexptest:v0.9',
-                },
                 '@case-insensitive' => 'true',
                 '@dotall' => 'true',
                 '@multiline' => 'true',
@@ -151,7 +123,6 @@ FactoryBot.define do
             '@framework' => 'JUnit',
             'unit:entry-point' => {
               '$1' => 'HelloWorldTest',
-              '@xmlns' => {'unit' => 'urn:proforma:tests:unittest:v1.1'},
             },
           },
           'regex:regexptest' =>
@@ -159,17 +130,13 @@ FactoryBot.define do
               '@xmlns' => {'regex' => 'urn:proforma:tests:regexptest:v0.9'},
               'regex:entry-point' => {
                 '$1' => 'HelloWorldTest',
-                '@xmlns' => {'regex' => 'urn:proforma:tests:regexptest:v0.9'},
               },
               'regex:parameter' => {
                 '$1' => 'gui',
-                '@xmlns' => {'regex' => 'urn:proforma:tests:regexptest:v0.9'},
               },
               'regex:regular-expressions' => {
-                '@xmlns' => {'regex' => 'urn:proforma:tests:regexptest:v0.9'},
                 'regex:regexp-disallow' => {
                   '$1' => 'foobar',
-                  '@xmlns' => {'regex' => 'urn:proforma:tests:regexptest:v0.9'},
                   '@dotall' => 'true',
                   '@multiline' => 'true',
                   '@free-spacing' => 'true',
@@ -182,7 +149,6 @@ FactoryBot.define do
             '@version' => '3.14',
             'check:max-checkstyle-warnings' => {
               '$1' => '4',
-              '@xmlns' => {'check' => 'urn:proforma:tests:java-checkstyle:v1.1'},
             },
           },
         }

--- a/spec/factories/test.rb
+++ b/spec/factories/test.rb
@@ -20,7 +20,43 @@ FactoryBot.define do
     end
 
     trait(:with_meta_data) do
-      meta_data { {namespace: {test_meta: 'data', test: 'test_data'}} }
+      meta_data do
+        {
+          'test-meta-data' => {
+            '@xmlns' => {
+              'namespace' => 'custom_namespace.org',
+            },
+            'namespace:meta' => {
+              '$1' => 'data',
+              '@xmlns' => {
+                'namespace' => 'custom_namespace.org',
+              },
+            },
+            'namespace:nested' => {
+              '@xmlns' => {
+                'namespace' => 'custom_namespace.org',
+              },
+              'namespace:foo' => {
+                '$1' => 'bar',
+                '@xmlns' => {
+                  'namespace' => 'custom_namespace.org',
+                },
+              },
+              'namespace:test' => {
+                '@xmlns' => {
+                  'namespace' => 'custom_namespace.org',
+                },
+                'namespace:abc' => {
+                  '$1' => '123',
+                  '@xmlns' => {
+                    'namespace' => 'custom_namespace.org',
+                  },
+                },
+              },
+            },
+          },
+        }
+      end
     end
 
     trait(:with_multiple_files) do

--- a/spec/proformaxml/exporter_spec.rb
+++ b/spec/proformaxml/exporter_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe ProformaXML::Exporter do
     context 'when task has meta_data' do
       let(:custom_namespaces) { [{prefix: 'namespace', uri: 'custom_namespace.org'}] }
       let(:task) do
-        build(:task, :populated, meta_data: {namespace: {meta: 'data', nested: {test: {abc: '123'}, foo: 'bar'}}})
+        build(:task, :populated, :with_meta_data)
       end
       let(:meta_data_node) { doc.xpath('/xmlns:task/xmlns:meta-data') }
 
@@ -146,7 +146,7 @@ RSpec.describe ProformaXML::Exporter do
         expect(meta_data_node).to have(1).items
       end
 
-      it 'adds two children nodes to meta-data node' do
+      it 'adds a child nodes to meta-data node' do
         expect(meta_data_node.children).to have(2).items
       end
 
@@ -319,7 +319,7 @@ RSpec.describe ProformaXML::Exporter do
         let(:custom_namespaces) { [{prefix: 'namespace', uri: 'custom_namespace.org'}] }
         let(:task) do
           build(:task, :populated,
-            tests: build_list(:test, 1, meta_data: {namespace: {meta: 'data', nested: {test: {abc: '123'}, foo: 'bar'}}}))
+            tests: build_list(:test, 1, :with_meta_data))
         end
         let(:meta_data_node) { doc.xpath('/xmlns:task/xmlns:tests/xmlns:test/xmlns:test-configuration/xmlns:test-meta-data') }
 

--- a/spec/proformaxml/importer_spec.rb
+++ b/spec/proformaxml/importer_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe ProformaXML::Importer do
 
     context 'when task has meta-data' do
       let(:export_namespaces) { [{prefix: 'namespace', uri: 'custom_namespace.org'}] }
-      let(:task) { build(:task, meta_data: {namespace: {meta: 'data', nested: {test: {abc: '123'}, foo: 'bar'}}}) }
+      let(:task) { build(:task, meta_data: {"meta-data"=>{"@xmlns"=>{"namespace"=>"custom_namespace.org"}, "namespace:meta"=>{"@xmlns"=>{"namespace"=>"custom_namespace.org"}, "namespace:nested"=>{"$1"=>"data", "@xmlns"=>{"namespace"=>"custom_namespace.org"}}}}}) }
 
       it 'successfully imports the task' do
         expect(imported_task).to be_an_equal_task_as ref_task

--- a/spec/proformaxml/importer_spec.rb
+++ b/spec/proformaxml/importer_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe ProformaXML::Importer do
 
     context 'when task has meta-data' do
       let(:export_namespaces) { [{prefix: 'namespace', uri: 'custom_namespace.org'}] }
-      let(:task) { build(:task, meta_data: {"meta-data"=>{"@xmlns"=>{"namespace"=>"custom_namespace.org"}, "namespace:meta"=>{"@xmlns"=>{"namespace"=>"custom_namespace.org"}, "namespace:nested"=>{"$1"=>"data", "@xmlns"=>{"namespace"=>"custom_namespace.org"}}}}}) }
+      let(:task) { build(:task, :with_meta_data) }
 
       it 'successfully imports the task' do
         expect(imported_task).to be_an_equal_task_as ref_task
@@ -185,7 +185,7 @@ RSpec.describe ProformaXML::Importer do
       context 'when test has meta-data' do
         let(:export_namespaces) { [{prefix: 'namespace', uri: 'custom_namespace.org'}] }
         let(:task) do
-          build(:task, tests: build_list(:test, 1, meta_data: {namespace: {meta: 'data', nested: {test: {abc: '123'}, foo: 'bar'}}}))
+          build(:task, tests: build_list(:test, 1, :with_meta_data))
         end
 
         it 'successfully imports the task' do

--- a/spec/proformaxml/importer_spec.rb
+++ b/spec/proformaxml/importer_spec.rb
@@ -42,27 +42,20 @@ RSpec.describe ProformaXML::Importer do
   describe '#perform' do
     subject(:perform) { importer.perform }
 
-    let(:imported_task) { perform[:task] }
-    let(:imported_namespaces) { perform[:custom_namespaces] }
+    let(:imported_task) { perform }
     let(:task) { build(:task) }
     let!(:ref_task) { task.dup }
     let(:zip_file) { Tempfile.new('proforma_test_zip_file') }
     let(:importer) { described_class.new(zip: zip_file) }
     let(:export_version) {}
-    let(:export_namespaces) { [] }
 
     before do
-      zip_file.write(ProformaXML::Exporter.new(task:, custom_namespaces: export_namespaces,
-        version: export_version).perform.string.force_encoding('UTF-8'))
+      zip_file.write(ProformaXML::Exporter.new(task:, version: export_version).perform.string.force_encoding('UTF-8'))
       zip_file.rewind
     end
 
     it 'successfully imports the task' do
       expect(imported_task).to be_an_equal_task_as ref_task
-    end
-
-    it 'evalutates the correct custom_namespaces' do
-      expect(imported_namespaces).to eql export_namespaces
     end
 
     context 'when task is populated' do
@@ -90,7 +83,6 @@ RSpec.describe ProformaXML::Importer do
     end
 
     context 'when task has meta-data' do
-      let(:export_namespaces) { [{prefix: 'namespace', uri: 'custom_namespace.org'}] }
       let(:task) { build(:task, :with_meta_data) }
 
       it 'successfully imports the task' do
@@ -164,11 +156,6 @@ RSpec.describe ProformaXML::Importer do
 
     context 'when task has a test' do
       let(:task) { build(:task, :with_test) }
-      let(:export_namespaces) { [{prefix: 'test', uri: 'test.com'}] }
-
-      it 'evaluates the correct custom_namespaces' do
-        expect(imported_namespaces).to eql export_namespaces
-      end
 
       it 'successfully imports the task' do
         expect(imported_task).to be_an_equal_task_as ref_task
@@ -183,7 +170,6 @@ RSpec.describe ProformaXML::Importer do
       end
 
       context 'when test has meta-data' do
-        let(:export_namespaces) { [{prefix: 'namespace', uri: 'custom_namespace.org'}] }
         let(:task) do
           build(:task, tests: build_list(:test, 1, :with_meta_data))
         end
@@ -213,7 +199,6 @@ RSpec.describe ProformaXML::Importer do
 
     context 'when task has a test and a model_solution' do
       let(:task) { build(:task, :with_test, :with_model_solution) }
-      let(:export_namespaces) { [{prefix: 'test', uri: 'test.com'}] }
 
       it 'successfully imports the task' do
         expect(imported_task).to be_an_equal_task_as ref_task
@@ -222,7 +207,6 @@ RSpec.describe ProformaXML::Importer do
 
     context 'when task has a test, a model_solution and 10 embedded files' do
       let(:task) { build(:task, :with_test, :with_model_solution, files: build_list(:task_file, 10, :populated, :small_content, :text)) }
-      let(:export_namespaces) { [{prefix: 'test', uri: 'test.com'}] }
 
       it 'successfully imports the task' do
         expect(imported_task).to be_an_equal_task_as ref_task
@@ -234,7 +218,6 @@ RSpec.describe ProformaXML::Importer do
       let(:files) { build_list(:task_file, 2, :populated, :small_content, :text) }
       let(:tests) { build_list(:test, 2, :populated, :with_multiple_files) }
       let(:model_solutions) { build_list(:model_solution, 2, :populated, :with_multiple_files) }
-      let(:export_namespaces) { [{prefix: 'test', uri: 'test.com'}] }
 
       it 'successfully imports the task' do
         expect(imported_task).to be_an_equal_task_as ref_task

--- a/spec/support/shared_examples/proforma/exporter.rb
+++ b/spec/support/shared_examples/proforma/exporter.rb
@@ -149,7 +149,7 @@ RSpec.shared_examples 'task node with test' do
 end
 
 RSpec.shared_examples 'task node with test in ProFormA 2.0' do
-  let(:exporter) { described_class.new(task:, custom_namespaces:, version: '2.0') }
+  let(:exporter) { described_class.new(task:, version: '2.0') }
 
   it_behaves_like 'task node with test'
 


### PR DESCRIPTION
Since we are now able to handle any node with dachsfisch, it makes sense to handle the meta_data that way too

- [x] check if we still need custom namespaces for exporter/importer

I did not see the need for custom namespace options anymore, since namespaces are generally extracted at the right positions. Therefore I removed those options as well.