### PR TITLE
Bundle Update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,4 +176,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.5.10
+   2.5.11


### PR DESCRIPTION
This PR bumps the bundler version only, since no dedicated Ruby version is given.